### PR TITLE
Adding circle.yml for integration with CircleCI and sample test project

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit.runners" version="1.9.2" />
+</packages>

--- a/Docker.DotNet.Tests/Docker.DotNet.Tests.csproj
+++ b/Docker.DotNet.Tests/Docker.DotNet.Tests.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{7AF82DEE-8011-4D37-8C7E-92F8508745FA}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Docker.DotNet.Tests</RootNamespace>
+    <AssemblyName>Docker.DotNet.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="xunit">
+      <HintPath>..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ImageTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Docker.DotNet.Tests/ImageTests.cs
+++ b/Docker.DotNet.Tests/ImageTests.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Docker.DotNet.Tests
+{
+    public class ImageTests
+    {
+        [Fact]
+        public void ListImagesTest()
+        {
+            Assert.True(true);
+        }
+    }
+}

--- a/Docker.DotNet.Tests/Properties/AssemblyInfo.cs
+++ b/Docker.DotNet.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Docker.DotNet.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Docker.DotNet.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("d4ae4ef8-ac7d-40bc-b9b8-f9e860d73e35")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Docker.DotNet.Tests/packages.config
+++ b/Docker.DotNet.Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runners" version="1.9.2" targetFramework="net45" />
+</packages>

--- a/Docker.DotNet.sln
+++ b/Docker.DotNet.sln
@@ -1,13 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+VisualStudioVersion = 12.0.31101.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Docker.DotNet", "Docker.DotNet\Docker.DotNet.csproj", "{4E6184DE-D4DA-4E82-9418-CE725EC35092}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Docker.DotNet.X509", "Docker.DotNet.X509\Docker.DotNet.X509.csproj", "{107FC0D5-57C8-42A6-80F0-8683679544FE}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Docker.DotNet.BasicAuth", "Docker.DotNet.BasicAuth\Docker.DotNet.BasicAuth.csproj", "{6D57F11F-B21A-45DB-A1D4-73AFCD68899C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Docker.DotNet.Tests", "Docker.DotNet.Tests\Docker.DotNet.Tests.csproj", "{7AF82DEE-8011-4D37-8C7E-92F8508745FA}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{4945B263-CE14-4615-8898-04C8D2F74368}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FE4DC472-1D25-4140-AE3E-91730BEBB8DC}"
+	ProjectSection(SolutionItems) = preProject
+		circle.yml = circle.yml
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +39,10 @@ Global
 		{6D57F11F-B21A-45DB-A1D4-73AFCD68899C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D57F11F-B21A-45DB-A1D4-73AFCD68899C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D57F11F-B21A-45DB-A1D4-73AFCD68899C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7AF82DEE-8011-4D37-8C7E-92F8508745FA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7AF82DEE-8011-4D37-8C7E-92F8508745FA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7AF82DEE-8011-4D37-8C7E-92F8508745FA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7AF82DEE-8011-4D37-8C7E-92F8508745FA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,12 @@
+general:
+  build_dir: ./
+dependencies:
+  pre:
+    - sudo apt-get install mono-devel autogen
+checkout:
+  post:
+    - curl --location 'https://nuget.org/nuget.exe' -o ./.nuget/NuGet.exe
+    - xbuild /p:Configuration=Release ./Docker.DotNet.sln
+test:
+  override:
+    - mono ./packages/xunit.runners.1.9.2/tools/xunit.console.exe ./Docker.DotNet.Tests/bin/Release/Docker.DotNet.Tests.dll


### PR DESCRIPTION
I added the circle.yml file for setting up the CircleCI build, as well as the xUnit test project with a sample test to get things started.  I've included the xUnit.Runners (1.9.2) package as well to allow for running the tests once pushed to CircleCI.   We may need to augment the .yml file to try to update the version of Mono being used, depending on whether or not you run into build issues.  I think it will install 3.2.8 on the Ubuntu image and the current version is 3.12.  You might also want to update it based on how you want to set up the Docker instances to test against.

If you need anything additional with this, just give me a shout.  Thanks!