### PR TITLE
Remove BoolQueryStringConverter from ListContainersParameters.Limit.

### DIFF
--- a/Docker.DotNet/Models/ListContainersParameters.cs
+++ b/Docker.DotNet/Models/ListContainersParameters.cs
@@ -92,8 +92,7 @@ namespace Docker.DotNet.Models
                 _allBackingField = value;
             }
         }
-
-        [QueryStringParameter("limit", false, typeof (BoolQueryStringConverter))]
+		
         public long? Limit
         {
             get { return _limitBackingField; }


### PR DESCRIPTION
Cause System.InvalidOperationException: Cannot convert type System.Int64 using Docker.DotNet.Models.BoolQueryStringConverter. 