### PR TITLE
Adding new NuSpec file with Microsoft.Bcl.Async dependency.

### DIFF
--- a/Docker.DotNet/Models/Config.cs
+++ b/Docker.DotNet/Models/Config.cs
@@ -84,6 +84,9 @@ namespace Docker.DotNet.Models
         [DataMember(Name = "HostConfig")]
         public HostConfig HostConfig { get; set; }
 
+        [DataMember(Name = "MacAddress")]
+        public string MacAddress { get;set; }
+
         public Config()
         {
         }

--- a/Docker.DotNet/Models/HostConfig.cs
+++ b/Docker.DotNet/Models/HostConfig.cs
@@ -35,6 +35,15 @@ namespace Docker.DotNet.Models
         [DataMember(Name = "RestartPolicy")]
         public RestartPolicy RestartPolicy { get; set; }
 
+        [DataMember(Name = "NetworkMode")]
+        public string NetworkMode { get;set; }
+
+        [DataMember(Name = "CapAdd")]
+        public IList<string> CapAdd { get;set; }
+
+        [DataMember(Name = "CapDrop")]
+        public IList<string> CapDrop { get;set; }
+
         // Commenting out LxcConf parameter because its type in the request
         // form and response form are not the same. (one example says it's [], another
         // example says it's {"key": "value"}, API is totally messed up with such inconsistencies.

--- a/Docker.DotNet/Models/SystemInfoResponse.cs
+++ b/Docker.DotNet/Models/SystemInfoResponse.cs
@@ -57,6 +57,24 @@ namespace Docker.DotNet.Models
         [DataMember(Name = "Debug")]
         public bool? Debug { get; set; }
 
+        [DataMember(Name = "NCPU")]
+        public string NCPU { get;set; }
+
+        [DataMember(Name = "MemTotal")]
+        public string MemTotal { get;set; }
+
+        [DataMember(Name = "ID")]
+        public string ID { get;set; }
+
+        [DataMember(Name = "DockerRootDir")]
+        public string DockerRootDir { get;set; }
+
+        [DataMember(Name = "OperatingSystem")]
+        public string OperatingSystem { get;set; }
+
+        [DataMember(Name = "Labels")]
+        public IList<string> Labels { get;set; }
+
         public SystemInfoResponse()
         {
         }

--- a/Docker.DotNet/Properties/AssemblyInfo.cs
+++ b/Docker.DotNet/Properties/AssemblyInfo.cs
@@ -29,5 +29,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.16.0.0")]
+[assembly: AssemblyFileVersion("1.16.0.0")]

--- a/NuGet/Docker.DotNet.1.1.2.nuspec
+++ b/NuGet/Docker.DotNet.1.1.2.nuspec
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+    <metadata>
+        <id>Docker.DotNet</id>
+        <version>1.1.2</version>
+        <title>Docker.DotNet</title>
+        <authors>Ahmet Alp Balkan</authors>
+        <owners>ahmetalpbalkan</owners>
+        <licenseUrl>https://github.com/ahmetalpbalkan/Docker.DotNet/blob/master/LICENSE</licenseUrl>
+        <projectUrl>https://github.com/ahmetalpbalkan/Docker.DotNet/</projectUrl>
+        <iconUrl>https://camo.githubusercontent.com/fa6d5c12609ed8a3ba1163b96f9e9979b8f59b0d/687474703a2f2f7765732e696f2f566663732f636f6e74656e74</iconUrl>
+        <requireLicenseAcceptance>false</requireLicenseAcceptance>
+        <description>This library allows you to use Docker Remote API programmatically in your .NET applications.
+
+It is portable (PCL), fully asynchronous, non-blocking and object-oriented way to interact with your Docker daemon programmatically. As of this release, it supports Docker Remote API v1.14.
+
+★ Documentation: https://github.com/ahmetalpbalkan/Docker.DotNet</description>
+        <summary>.NET Client Library for Docker Remote API.</summary>
+        <copyright />
+        <dependencies>
+            <dependency id="Newtonsoft.Json" version="6.0.4" />
+            <dependency id="Microsoft.Net.Http" version="2.2.28" />
+            <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
+        </dependencies>
+    </metadata>
+    <files>
+        <file src="..\Docker.DotNet\bin\Release\Docker.DotNet.dll" target="lib\portable-net45+sl5+wp8+win8\Docker.DotNet.dll" />
+    </files>
+</package>


### PR DESCRIPTION
Adding dependency to NuSpec file as per issue https://github.com/ahmetalpbalkan/Docker.DotNet/issues/18.  NuGet package will need to be rebuilt and deployed in order for changes to take effect.