### PR TITLE
ignore nuget packages folder all together

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,15 +134,6 @@ publish/
 *.pubxml
 *.publishproj
 
-# NuGet Packages
-*.nupkg
-# The packages folder can be ignored because of Package Restore
-**/packages/*
-# except build/, which is used as an MSBuild target.
-!**/packages/build/
-# If using the old MSBuild-Integrated Package Restore, uncomment this:
-#!**/packages/repositories.config
-
 # Windows Azure Build Output
 csx/
 *.build.csdef
@@ -185,3 +176,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# NuGet Packages Folder
+packages/


### PR DESCRIPTION
properly ignores the packages folder.