### PR TITLE
made DockerClient to use only one handler per instance

### DIFF
--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -8,6 +8,7 @@ namespace Docker.DotNet.BasicAuth
 {
     public class BasicAuthCredentials : Credentials
     {
+        private readonly HttpMessageHandler _handler;
         private readonly SecureString _username;
         private readonly SecureString _password;
         private readonly bool _isTls;
@@ -24,6 +25,7 @@ namespace Docker.DotNet.BasicAuth
                 throw new ArgumentException("password");
             }
 
+            _handler = new HttpClientHandler();
             _username = username;
             _password = password;
             _isTls = isTls;
@@ -41,6 +43,7 @@ namespace Docker.DotNet.BasicAuth
                 throw new ArgumentException("password");
             }
 
+            _handler = new HttpClientHandler();
             _username = ConvertToSecureString(username);
             _password = ConvertToSecureString(password);
             _isTls = isTls;
@@ -48,7 +51,7 @@ namespace Docker.DotNet.BasicAuth
 
         public override HttpClient BuildHttpClient()
         {
-            var httpClient = new HttpClient();
+            var httpClient = new HttpClient(_handler, false);
             httpClient.DefaultRequestHeaders.Add("Authorization", BuildBasicAuth(_username, _password));
 
             return httpClient;
@@ -93,6 +96,11 @@ namespace Docker.DotNet.BasicAuth
             {
                 Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
             }
+        }
+
+        public override void Dispose()
+        {
+            _handler.Dispose();
         }
     }
 }

--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -5,14 +5,9 @@ namespace Docker.DotNet.X509
 {
     public class CertificateCredentials : Credentials
     {
-        public X509Certificate2 ClientCertificate { get; private set; }
+        private readonly HttpMessageHandler _handler;
 
         public CertificateCredentials(X509Certificate2 clientCertificate)
-        {
-            this.ClientCertificate = clientCertificate;
-        }
-
-        public override HttpClient BuildHttpClient()
         {
             WebRequestHandler certHandler = new WebRequestHandler()
             {
@@ -20,14 +15,24 @@ namespace Docker.DotNet.X509
                 UseDefaultCredentials = false
             };
 
-            certHandler.ClientCertificates.Add(this.ClientCertificate);
+            certHandler.ClientCertificates.Add(clientCertificate);
 
-            return new HttpClient(certHandler);
+            _handler = certHandler;
+        }
+
+        public override HttpClient BuildHttpClient()
+        {
+            return new HttpClient(_handler, false);
         }
 
         public override bool IsTlsCredentials()
         {
             return true;
+        }
+
+        public override void Dispose()
+        {
+            _handler.Dispose();
         }
     }
 }

--- a/Docker.DotNet/AnonymousCredentials.cs
+++ b/Docker.DotNet/AnonymousCredentials.cs
@@ -4,18 +4,26 @@ namespace Docker.DotNet
 {
     public class AnonymousCredentials : Credentials
     {
+        private readonly HttpMessageHandler _handler;
+
         public AnonymousCredentials()
         {
+            _handler = new HttpClientHandler();
         }
 
         public override HttpClient BuildHttpClient()
         {
-            return new HttpClient();
+            return new HttpClient(_handler, false);
         }
 
         public override bool IsTlsCredentials()
         {
             return false;
+        }
+
+        public override void Dispose()
+        {
+            _handler.Dispose();
         }
     }
 }

--- a/Docker.DotNet/Credentials.cs
+++ b/Docker.DotNet/Credentials.cs
@@ -1,11 +1,16 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 
 namespace Docker.DotNet
 {
-    public abstract class Credentials
+    public abstract class Credentials : IDisposable
     {
         public abstract HttpClient BuildHttpClient();
 
         public abstract bool IsTlsCredentials();
+
+        public virtual void Dispose()
+        {
+        }
     }
 }

--- a/Docker.DotNet/DockerClient.cs
+++ b/Docker.DotNet/DockerClient.cs
@@ -89,14 +89,16 @@ namespace Docker.DotNet
 
         private async Task<HttpResponseMessage> MakeRequestInnerAsync(TimeSpan? requestTimeout, HttpCompletionOption completionOption, HttpMethod method, string path, IQueryString queryString, IDictionary<string, string> headers, IRequestContent data, CancellationToken cancellationToken)
         {
-            HttpClient client = this.GetHttpClient();
-            if (requestTimeout.HasValue)
+            using (HttpClient client = this.GetHttpClient())
             {
-                client.Timeout = requestTimeout.Value;
-            }
+                if (requestTimeout.HasValue)
+                {
+                    client.Timeout = requestTimeout.Value;
+                }
 
-            HttpRequestMessage request = PrepareRequest(method, path, queryString, headers, data);
-            return await client.SendAsync(request, completionOption, cancellationToken);
+                HttpRequestMessage request = PrepareRequest(method, path, queryString, headers, data);
+                return await client.SendAsync(request, completionOption, cancellationToken);
+            }
         }
 
         #endregion
@@ -143,6 +145,11 @@ namespace Docker.DotNet
             }
 
             return request;
+        }
+
+        public void Dispose()
+        {
+            Configuration.Dispose();
         }
     }
 

--- a/Docker.DotNet/DockerClientConfiguration.cs
+++ b/Docker.DotNet/DockerClientConfiguration.cs
@@ -2,7 +2,7 @@
 
 namespace Docker.DotNet
 {
-    public class DockerClientConfiguration
+    public class DockerClientConfiguration : IDisposable
     {
         public Uri EndpointBaseUri { get; internal set; }
 
@@ -53,6 +53,11 @@ namespace Docker.DotNet
             }
 
             return builder.Uri;
+        }
+
+        public void Dispose()
+        {
+            Credentials.Dispose();
         }
     }
 }

--- a/Docker.DotNet/IDockerClient.cs
+++ b/Docker.DotNet/IDockerClient.cs
@@ -1,6 +1,8 @@
-﻿namespace Docker.DotNet
+﻿using System;
+
+namespace Docker.DotNet
 {
-    public interface IDockerClient
+    public interface IDockerClient : IDisposable
     {
         IImageOperations Images { get; }
 


### PR DESCRIPTION
The current implementation of `DockerClient` does two things wrong:

 - It creates an `HttpClient` instance each time you make a request. This will result in creating inner handlers in each request which does the connection pooling. 
 - It leaves `HttpClient` instances undisposed which will result in open TCP connections as inner handlers don't close them for certain period of time by default.

The best usage of `HttpClient` is to create one instance of this and use it for the entire app lifetime as its members are thread safe + its inner handler does connection pooling. See [here](http://stackoverflow.com/questions/15705092/do-httpclient-and-httpclienthandler-have-to-be-disposed) for more info.

However, as you have special cases for credentials, I started disposing `HttpClient` but left the inner handler undisposed for a `DockerClient` instance (this might be handled better but I thought this would be enough as the first pass on this). Disposing `DockerClient` instance will dispose everything. Having one instance of `DockerClient` per application lifecycle would be the recommended usage for `DockerClient` now.

Didn't have a chance to do a manual run to see whether I screwed up anything. So, it would be good to go through that first. I can probably do that later sometimes if you are OK to wait a bit more on this.