### PR TITLE
Fix for defect where streams are being closed prematurely

### DIFF
--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -1,17 +1,67 @@
 ﻿using System;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
 using System.Security;
 using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Docker.DotNet.BasicAuth
 {
     public class BasicAuthCredentials : Credentials
     {
-        private readonly HttpMessageHandler _handler;
-        private readonly SecureString _username;
-        private readonly SecureString _password;
+        private class BasicAuthHandler : HttpClientHandler
+        {
+            SecureString _username;
+            SecureString _password;
+
+            public BasicAuthHandler(SecureString username, SecureString password)
+            {
+                _username = username;
+                _password = password;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Basic", BuildParameters());
+
+                return base.SendAsync(request, cancellationToken);
+            }
+
+            private string BuildParameters()
+            {
+                string authInfo = string.Format("{0}:{1}", ConvertToUnsecureString(_username),
+                    ConvertToUnsecureString(_password));
+
+                return Convert.ToBase64String(Encoding.Default.GetBytes(authInfo));
+            }
+
+            private static string ConvertToUnsecureString(SecureString secureString)
+            {
+                IntPtr unmanagedString = IntPtr.Zero;
+                try
+                {
+                    unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+                    return Marshal.PtrToStringUni(unmanagedString);
+                }
+                finally
+                {
+                    Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
+                }
+            }
+        }
+
+        private readonly BasicAuthHandler _handler;
         private readonly bool _isTls;
+
+        public override HttpMessageHandler Handler
+        {
+            get
+            {
+                return _handler;
+            }
+        }
 
         public BasicAuthCredentials(SecureString username, SecureString password, bool isTls = false)
         {
@@ -25,9 +75,8 @@ namespace Docker.DotNet.BasicAuth
                 throw new ArgumentException("password");
             }
 
-            _handler = new HttpClientHandler();
-            _username = username;
-            _password = password;
+            _handler = new BasicAuthHandler(username, password);
+
             _isTls = isTls;
         }
 
@@ -43,31 +92,14 @@ namespace Docker.DotNet.BasicAuth
                 throw new ArgumentException("password");
             }
 
-            _handler = new HttpClientHandler();
-            _username = ConvertToSecureString(username);
-            _password = ConvertToSecureString(password);
+            _handler = new BasicAuthHandler(ConvertToSecureString(username), ConvertToSecureString(password));
+
             _isTls = isTls;
-        }
-
-        public override HttpClient BuildHttpClient()
-        {
-            var httpClient = new HttpClient(_handler, false);
-            httpClient.DefaultRequestHeaders.Add("Authorization", BuildBasicAuth(_username, _password));
-
-            return httpClient;
         }
 
         public override bool IsTlsCredentials()
         {
             return _isTls;
-        }
-
-        private static string BuildBasicAuth(SecureString username, SecureString password)
-        {
-            string authInfo = string.Format("{0}:{1}", ConvertToUnsecureString(username),
-                ConvertToUnsecureString(password));
-
-            return string.Format("Basic {0}", Convert.ToBase64String(Encoding.Default.GetBytes(authInfo)));
         }
 
         private static SecureString ConvertToSecureString(string str)
@@ -82,20 +114,6 @@ namespace Docker.DotNet.BasicAuth
                 }
             }
             return secureStr;
-        }
-
-        private static string ConvertToUnsecureString(SecureString secureString)
-        {
-            IntPtr unmanagedString = IntPtr.Zero;
-            try
-            {
-                unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(secureString);
-                return Marshal.PtrToStringUni(unmanagedString);
-            }
-            finally
-            {
-                Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
-            }
         }
 
         public override void Dispose()

--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -16,8 +16,8 @@ namespace Docker.DotNet.BasicAuth
 
         private class BasicAuthHandler : HttpClientHandler
         {
-            SecureString _username;
-            SecureString _password;
+            private readonly SecureString _username;
+            private readonly SecureString _password;
 
             public BasicAuthHandler(SecureString username, SecureString password)
             {

--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -11,6 +11,9 @@ namespace Docker.DotNet.BasicAuth
 {
     public class BasicAuthCredentials : Credentials
     {
+        private readonly BasicAuthHandler _handler;
+        private readonly bool _isTls;
+
         private class BasicAuthHandler : HttpClientHandler
         {
             SecureString _username;
@@ -51,9 +54,6 @@ namespace Docker.DotNet.BasicAuth
                 }
             }
         }
-
-        private readonly BasicAuthHandler _handler;
-        private readonly bool _isTls;
 
         public override HttpMessageHandler Handler
         {

--- a/Docker.DotNet.BasicAuth/BasicAuthHandler.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthHandler.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Docker.DotNet.BasicAuth
+{
+    internal class BasicAuthHandler : DelegatingHandler
+    {
+        private readonly SecureString _username;
+        private readonly SecureString _password;
+
+        public BasicAuthHandler(SecureString username, SecureString password, HttpMessageHandler innerHandler) : base(innerHandler)
+        {
+            if (username == null)
+            {
+                throw new ArgumentException("username");
+            }
+
+            if (password == null)
+            {
+                throw new ArgumentException("password");
+            }
+
+            _username = username;
+            _password = password;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Basic", BuildParameters());
+
+            return base.SendAsync(request, cancellationToken);
+        }
+
+        private string BuildParameters()
+        {
+            string authInfo = string.Format("{0}:{1}", ConvertToUnsecureString(_username),
+                ConvertToUnsecureString(_password));
+
+            return Convert.ToBase64String(Encoding.Default.GetBytes(authInfo));
+        }
+
+        private static string ConvertToUnsecureString(SecureString secureString)
+        {
+            IntPtr unmanagedString = IntPtr.Zero;
+
+            try
+            {
+                unmanagedString = Marshal.SecureStringToGlobalAllocUnicode(secureString);
+                return Marshal.PtrToStringUni(unmanagedString);
+            }
+            finally
+            {
+                Marshal.ZeroFreeGlobalAllocUnicode(unmanagedString);
+            }
+        }
+    }
+}

--- a/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.csproj
+++ b/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.csproj
@@ -48,6 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BasicAuthCredentials.cs" />
+    <Compile Include="BasicAuthHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -1,28 +1,31 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
+using System.Threading;
 
 namespace Docker.DotNet.X509
 {
     public class CertificateCredentials : Credentials
     {
-        private readonly HttpMessageHandler _handler;
+        private readonly WebRequestHandler _handler;
 
         public CertificateCredentials(X509Certificate2 clientCertificate)
         {
-            WebRequestHandler certHandler = new WebRequestHandler()
+            _handler = new WebRequestHandler()
             {
                 ClientCertificateOptions = ClientCertificateOption.Manual,
-                UseDefaultCredentials = false
+                UseDefaultCredentials = false,
             };
 
-            certHandler.ClientCertificates.Add(clientCertificate);
-
-            _handler = certHandler;
+            _handler.ClientCertificates.Add(clientCertificate);
         }
 
-        public override HttpClient BuildHttpClient()
+        public override HttpMessageHandler Handler
         {
-            return new HttpClient(_handler, false);
+            get
+            {
+                return _handler;
+            }
         }
 
         public override bool IsTlsCredentials()

--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -14,7 +14,7 @@ namespace Docker.DotNet.X509
             _handler = new WebRequestHandler()
             {
                 ClientCertificateOptions = ClientCertificateOption.Manual,
-                UseDefaultCredentials = false,
+                UseDefaultCredentials = false
             };
 
             _handler.ClientCertificates.Add(clientCertificate);

--- a/Docker.DotNet/AnonymousCredentials.cs
+++ b/Docker.DotNet/AnonymousCredentials.cs
@@ -1,19 +1,24 @@
-﻿using System.Net.Http;
+﻿using System;
+using System.Net.Http;
+using System.Threading;
 
 namespace Docker.DotNet
 {
     public class AnonymousCredentials : Credentials
     {
-        private readonly HttpMessageHandler _handler;
+        private readonly HttpClientHandler _handler;
 
         public AnonymousCredentials()
         {
             _handler = new HttpClientHandler();
         }
 
-        public override HttpClient BuildHttpClient()
+        public override HttpMessageHandler Handler
         {
-            return new HttpClient(_handler, false);
+            get
+            {
+                return _handler;
+            }
         }
 
         public override bool IsTlsCredentials()

--- a/Docker.DotNet/ContainerOperations.cs
+++ b/Docker.DotNet/ContainerOperations.cs
@@ -36,7 +36,7 @@ namespace Docker.DotNet
 
             string path = "containers/json";
             IQueryString queryParameters = new QueryString<ListContainersParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerListResponse[]>(response.Body);
         }
 
@@ -48,7 +48,7 @@ namespace Docker.DotNet
             }
 
             string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/json", id);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerResponse>(response.Body);
         }
 
@@ -72,7 +72,7 @@ namespace Docker.DotNet
             {
                 data = new JsonRequestContent<Config>(parameters.Config, this.Client.JsonSerializer);
             }
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, qs, data);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, qs, data).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<CreateContainerResponse>(response.Body);
         }
 
@@ -101,7 +101,7 @@ namespace Docker.DotNet
 
             string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/top", id);
             IQueryString queryParameters = new QueryString<ListProcessesParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, queryParameters);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerProcessesResponse>(response.Body);
         }
 
@@ -113,7 +113,7 @@ namespace Docker.DotNet
             }
 
             string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/changes", id);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<FilesystemChange[]>(response.Body);
         }
 
@@ -130,7 +130,7 @@ namespace Docker.DotNet
             {
                 data = new JsonRequestContent<HostConfig>(hostConfig, this.Client.JsonSerializer);
             }
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, data);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, data).ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotModified;
         }
 
@@ -147,7 +147,7 @@ namespace Docker.DotNet
             {
                 data = new JsonRequestContent<ExecCreateContainerConfig>(parameters.Config, this.Client.JsonSerializer);
             }
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, data);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, data).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ExecCreateContainerResponse>(response.Body);
         }
 
@@ -167,7 +167,7 @@ namespace Docker.DotNet
             IQueryString queryParameters = new QueryString<StopContainerParameters>(parameters);
             // since specified wait timespan can be greater than HttpClient's default, we set the
             // client timeout to infinite and provide a cancellation token.
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, queryParameters, null, new TimeSpan?(new TimeSpan(Timeout.Infinite)), cancellationToken);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, queryParameters, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotModified;
         }
 
@@ -238,7 +238,7 @@ namespace Docker.DotNet
             }
 
             string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/wait", id);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, null, new TimeSpan?(new TimeSpan(Timeout.Infinite)), cancellationToken);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<WaitContainerResponse>(response.Body);
         }
 

--- a/Docker.DotNet/Credentials.cs
+++ b/Docker.DotNet/Credentials.cs
@@ -5,9 +5,9 @@ namespace Docker.DotNet
 {
     public abstract class Credentials : IDisposable
     {
-        public abstract HttpClient BuildHttpClient();
-
         public abstract bool IsTlsCredentials();
+
+        public abstract HttpMessageHandler Handler { get; }
 
         public virtual void Dispose()
         {

--- a/Docker.DotNet/DockerClient.cs
+++ b/Docker.DotNet/DockerClient.cs
@@ -33,22 +33,26 @@ namespace Docker.DotNet
             }
         };
 
+        private readonly HttpClient _client;
+        private readonly TimeSpan _defaultTimeout;
+
         internal readonly IEnumerable<ApiResponseErrorHandlingDelegate> NoErrorHandlers = Enumerable.Empty<ApiResponseErrorHandlingDelegate>();
 
         internal DockerClient(DockerClientConfiguration configuration, Version requestedApiVersion)
         {
-            this.Configuration = configuration;
-            this.RequestedApiVersion = requestedApiVersion;
-            this.JsonSerializer = new JsonSerializer();
+            Configuration = configuration;
+            RequestedApiVersion = requestedApiVersion;
+            JsonSerializer = new JsonSerializer();
 
-            this.Images = new ImageOperations(this);
-            this.Containers = new ContainerOperations(this);
-            this.Miscellaneous = new MiscellaneousOperations(this);
-        }
+            Images = new ImageOperations(this);
+            Containers = new ContainerOperations(this);
+            Miscellaneous = new MiscellaneousOperations(this);
 
-        private HttpClient GetHttpClient()
-        {
-            return this.Configuration.Credentials.BuildHttpClient();
+            _client = new HttpClient(Configuration.Credentials.Handler, false);
+
+            _defaultTimeout = _client.Timeout;
+
+            _client.Timeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
         }
 
         #region Convenience methods
@@ -74,31 +78,49 @@ namespace Docker.DotNet
 
         internal async Task<DockerApiResponse> MakeRequestAsync(IEnumerable<ApiResponseErrorHandlingDelegate> errorHandlers, HttpMethod method, string path, IQueryString queryString, IRequestContent data, TimeSpan? timeout, CancellationToken cancellationToken)
         {
-            HttpResponseMessage response = await this.MakeRequestInnerAsync(null, HttpCompletionOption.ResponseContentRead, method, path, queryString, null, data, cancellationToken);
-            string body = await response.Content.ReadAsStringAsync();
+            HttpResponseMessage response = await MakeRequestInnerAsync(null, HttpCompletionOption.ResponseContentRead, method, path, queryString, null, data, cancellationToken).ConfigureAwait(false);
+
+            string body = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
             HandleIfErrorResponse(response.StatusCode, body, errorHandlers);
+
             return new DockerApiResponse(response.StatusCode, body);
         }
 
         internal async Task<Stream> MakeRequestForStreamAsync(IEnumerable<ApiResponseErrorHandlingDelegate> errorHandlers, HttpMethod method, string path, IQueryString queryString, IDictionary<string, string> headers, IRequestContent data, CancellationToken cancellationToken)
         {
-            HttpResponseMessage response = await MakeRequestInnerAsync(TimeSpan.FromMilliseconds(Timeout.Infinite), HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, data, cancellationToken);
+            HttpResponseMessage response = await MakeRequestInnerAsync(TimeSpan.FromMilliseconds(Timeout.Infinite), HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, data, cancellationToken).ConfigureAwait(false);
+
             HandleIfErrorResponse(response.StatusCode, null, errorHandlers);
-            return await response.Content.ReadAsStreamAsync();
+
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
 
-        private async Task<HttpResponseMessage> MakeRequestInnerAsync(TimeSpan? requestTimeout, HttpCompletionOption completionOption, HttpMethod method, string path, IQueryString queryString, IDictionary<string, string> headers, IRequestContent data, CancellationToken cancellationToken)
+        private Task<HttpResponseMessage> MakeRequestInnerAsync(TimeSpan? requestTimeout, HttpCompletionOption completionOption, HttpMethod method, string path, IQueryString queryString, IDictionary<string, string> headers, IRequestContent data, CancellationToken cancellationToken)
         {
-            using (HttpClient client = this.GetHttpClient())
-            {
-                if (requestTimeout.HasValue)
-                {
-                    client.Timeout = requestTimeout.Value;
-                }
+            HttpRequestMessage request = PrepareRequest(method, path, queryString, headers, data);
 
-                HttpRequestMessage request = PrepareRequest(method, path, queryString, headers, data);
-                return await client.SendAsync(request, completionOption, cancellationToken);
+            if (requestTimeout.HasValue)
+            {
+                if (requestTimeout.Value != TimeSpan.FromMilliseconds(Timeout.Infinite))
+                {
+                    CancellationTokenSource timeoutTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                    timeoutTokenSource.CancelAfter(requestTimeout.Value);
+
+                    cancellationToken = timeoutTokenSource.Token;
+                }
             }
+            else
+            {
+                CancellationTokenSource timeoutTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+                timeoutTokenSource.CancelAfter(_defaultTimeout);
+
+                cancellationToken = timeoutTokenSource.Token;
+            }
+
+            return _client.SendAsync(request, completionOption, cancellationToken);
         }
 
         #endregion
@@ -116,6 +138,7 @@ namespace Docker.DotNet
             {
                 handler(statusCode, responseBody);
             }
+
             _defaultErrorHandlingDelegate(statusCode, responseBody);
         }
 
@@ -128,8 +151,10 @@ namespace Docker.DotNet
                 throw new ArgumentNullException("path");
             }
 
-            HttpRequestMessage request = new HttpRequestMessage(method, HttpUtility.BuildUri(this.Configuration.EndpointBaseUri, this.RequestedApiVersion, path, queryString));
+            HttpRequestMessage request = new HttpRequestMessage(method, HttpUtility.BuildUri(Configuration.EndpointBaseUri, RequestedApiVersion, path, queryString));
+
             request.Headers.Add("User-Agent", UserAgent);
+
             if (headers != null)
             {
                 foreach (var header in headers)

--- a/Docker.DotNet/DockerClientConfiguration.cs
+++ b/Docker.DotNet/DockerClientConfiguration.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Net.Http;
 
 namespace Docker.DotNet
 {

--- a/Docker.DotNet/DockerClientConfiguration.cs
+++ b/Docker.DotNet/DockerClientConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net.Http;
 
 namespace Docker.DotNet
 {
@@ -25,8 +26,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException("credentials");
             }
 
-            this.EndpointBaseUri = SanitizeEndpoint(endpoint, credentials.IsTlsCredentials());
-            this.Credentials = credentials;
+            EndpointBaseUri = SanitizeEndpoint(endpoint, credentials.IsTlsCredentials());
+            Credentials = credentials;
         }
 
         public DockerClient CreateClient()

--- a/Docker.DotNet/ImageOperations.cs
+++ b/Docker.DotNet/ImageOperations.cs
@@ -39,7 +39,7 @@ namespace Docker.DotNet
 
             string path = "images/json";
             IQueryString queryParameters = new QueryString<ListImagesParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ImageListResponse[]>(response.Body);
         }
 
@@ -51,7 +51,7 @@ namespace Docker.DotNet
             }
 
             string path = string.Format(CultureInfo.InvariantCulture, "images/{0}/json", name);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchImageHandler}, HttpMethod.Get, path, null);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchImageHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ImageResponse>(response.Body);
         }
 
@@ -63,7 +63,7 @@ namespace Docker.DotNet
             }
 
             string path = string.Format(CultureInfo.InvariantCulture, "images/{0}/history", name);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchImageHandler}, HttpMethod.Get, path, null);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchImageHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ImageHistoryResponse[]>(response.Body);
         }
 
@@ -99,7 +99,7 @@ namespace Docker.DotNet
 
             string path = string.Format(CultureInfo.InvariantCulture, "images/{0}", name);
             IQueryString queryParameters = new QueryString<DeleteImageParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchImageHandler}, HttpMethod.Delete, path, queryParameters);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(new[] {NoSuchImageHandler}, HttpMethod.Delete, path, queryParameters).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<Dictionary<string, string>[]>(response.Body);
         }
 
@@ -112,7 +112,7 @@ namespace Docker.DotNet
 
             string path = "images/search";
             IQueryString queryParameters = new QueryString<SearchImagesParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ImageSearchResponse[]>(response.Body);
         }
 

--- a/Docker.DotNet/MiscellaneousOperations.cs
+++ b/Docker.DotNet/MiscellaneousOperations.cs
@@ -32,7 +32,7 @@ namespace Docker.DotNet
         public async Task<VersionResponse> GetVersionAsync()
         {
             const string path = "version";
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, null);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<VersionResponse>(response.Body);
         }
 
@@ -44,7 +44,7 @@ namespace Docker.DotNet
         public async Task<SystemInfoResponse> GetSystemInfoAsync()
         {
             const string path = "info";
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, null);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Get, path, null).ConfigureAwait(false); ;
             return this.Client.JsonSerializer.DeserializeObject<SystemInfoResponse>(response.Body);
         }
 
@@ -70,7 +70,7 @@ namespace Docker.DotNet
             JsonRequestContent<Config> data = parameters.Config == null ? null : new JsonRequestContent<Config>(parameters.Config, this.Client.JsonSerializer);
             const string path = "commit";
             IQueryString queryParameters = new QueryString<CommitContainerChangesParameters>(parameters);
-            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Post, path, queryParameters, data);
+            DockerApiResponse response = await this.Client.MakeRequestAsync(this.Client.NoErrorHandlers, HttpMethod.Post, path, queryParameters, data).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<CommitContainerChangesResponse>(response.Body);
         }
 


### PR DESCRIPTION
When calling methods that return a stream, the stream cannot be read from due to HttpClient being disposed, which results in any requests still in flight being disposed of.

I've done some refactoring so that HttpClient has only one instance and then the credential instances inject a httpmessagehandler rather than being responsible for creating the HttpClient.

Because I've had to make it a single instance I've had to make changes to the way timeouts work, so instead of setting the timeout value on HttpClient I configure the cancellation token to timeout which behaviour wise is the same.

I've also added configure await on awaited calls just as it's considered good practice.