### PR TITLE
Added features introduced in api version 1.20

### DIFF
--- a/Docker.DotNet/ContainerOperations.cs
+++ b/Docker.DotNet/ContainerOperations.cs
@@ -304,7 +304,7 @@ namespace Docker.DotNet
             return this.Client.MakeRequestForStreamAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, data, cancellationToken);
         }
 
-        public async Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statsOnly, CancellationToken cancellationToken)
+        public async Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statOnly, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(id))
             {
@@ -320,20 +320,20 @@ namespace Docker.DotNet
 
             string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/archive", id);
 
-            DockerApiStreamedResponse response = await this.Client.MakeRequestForStreamedResponseAsync(new[] { NoSuchContainerHandler }, statsOnly ? HttpMethod.Head : HttpMethod.Get, path, queryParameters, null, cancellationToken);
+            DockerApiStreamedResponse response = await this.Client.MakeRequestForStreamedResponseAsync(new[] { NoSuchContainerHandler }, statOnly ? HttpMethod.Head : HttpMethod.Get, path, queryParameters, null, cancellationToken);
 
             string statHeader = response.Headers.GetValues("X-Docker-Container-Path-Stat").First();
 
             byte[] bytes = Convert.FromBase64String(statHeader);
 
-            string stats = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+            string stat = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 
-            ContainerPathStats pathStats = this.Client.JsonSerializer.DeserializeObject<ContainerPathStats>(stats);
+            ContainerPathStat pathStat = this.Client.JsonSerializer.DeserializeObject<ContainerPathStat>(stat);
 
             return new GetArchiveFromContainerResponse
             {
-                Stats = pathStats,
-                Stream = statsOnly ? null : response.Body
+                Stat = pathStat,
+                Stream = statOnly ? null : response.Body
             };
         }
 

--- a/Docker.DotNet/ContainerOperations.cs
+++ b/Docker.DotNet/ContainerOperations.cs
@@ -7,6 +7,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Docker.DotNet.Models;
+using System.Linq;
+using System.Text;
 
 namespace Docker.DotNet
 {
@@ -276,6 +278,7 @@ namespace Docker.DotNet
             return this.Client.MakeRequestForStreamAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, queryParameters, null, cancellationToken);
         }
 
+        [Obsolete("Deprecated since api version 1.20 in favor of the archive methods")]
         public Task<Stream> CopyFromContainerAsync(string id, CopyFromContainerParameters parameters, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(id))
@@ -299,6 +302,60 @@ namespace Docker.DotNet
 
             string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/copy", id);
             return this.Client.MakeRequestForStreamAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, data, cancellationToken);
+        }
+
+        public async Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statsOnly, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException("id");
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException("parameters");
+            }
+
+            IQueryString queryParameters = new QueryString<GetArchiveFromContainerParameters>(parameters);
+
+            string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/archive", id);
+
+            DockerApiStreamedResponse response = await this.Client.MakeRequestForStreamedResponseAsync(new[] { NoSuchContainerHandler }, statsOnly ? HttpMethod.Head : HttpMethod.Get, path, queryParameters, null, cancellationToken);
+
+            string statHeader = response.Headers.GetValues("X-Docker-Container-Path-Stat").First();
+
+            byte[] bytes = Convert.FromBase64String(statHeader);
+
+            string stats = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+
+            ContainerPathStats pathStats = this.Client.JsonSerializer.DeserializeObject<ContainerPathStats>(stats);
+
+            return new GetArchiveFromContainerResponse
+            {
+                Stats = pathStats,
+                Stream = statsOnly ? null : response.Body
+            };
+        }
+
+        public Task ExtractArchiveToContainerAsync(string id, ExtractArchiveToContainerParameters parameters, Stream stream, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException("id");
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException("parameters");
+            }
+
+            IQueryString queryParameters = new QueryString<ExtractArchiveToContainerParameters>(parameters);
+
+            BinaryRequestContent data = new BinaryRequestContent(stream, "application/x-tar");
+
+            string path = string.Format(CultureInfo.InvariantCulture, "containers/{0}/archive", id);
+
+            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Put, path, queryParameters, data, null, cancellationToken);
         }
     }
 }

--- a/Docker.DotNet/Docker.DotNet.csproj
+++ b/Docker.DotNet/Docker.DotNet.csproj
@@ -41,10 +41,15 @@
     <Compile Include="Credentials.cs" />
     <Compile Include="DockerApiException.cs" />
     <Compile Include="DockerApiResponse.cs" />
+    <Compile Include="DockerApiStreamedResponse.cs" />
     <Compile Include="DockerClient.cs" />
     <Compile Include="DockerClientConfiguration.cs" />
     <Compile Include="DockerContainerNotFoundException.cs" />
     <Compile Include="DockerImageNotFoundException.cs" />
+    <Compile Include="Models\ContainerPathStats.cs" />
+    <Compile Include="Models\ExtractArchiveToContainerParameters.cs" />
+    <Compile Include="Models\GetArchiveFromContainerParameters.cs" />
+    <Compile Include="Models\GetArchiveFromContainerResponse.cs" />
     <Compile Include="HttpUtility.cs" />
     <Compile Include="IContainerOperations.cs" />
     <Compile Include="IDockerClient.cs" />

--- a/Docker.DotNet/Docker.DotNet.csproj
+++ b/Docker.DotNet/Docker.DotNet.csproj
@@ -46,7 +46,7 @@
     <Compile Include="DockerClientConfiguration.cs" />
     <Compile Include="DockerContainerNotFoundException.cs" />
     <Compile Include="DockerImageNotFoundException.cs" />
-    <Compile Include="Models\ContainerPathStats.cs" />
+    <Compile Include="Models\ContainerPathStat.cs" />
     <Compile Include="Models\ExtractArchiveToContainerParameters.cs" />
     <Compile Include="Models\GetArchiveFromContainerParameters.cs" />
     <Compile Include="Models\GetArchiveFromContainerResponse.cs" />

--- a/Docker.DotNet/DockerApiStreamedResponse.cs
+++ b/Docker.DotNet/DockerApiStreamedResponse.cs
@@ -1,0 +1,22 @@
+﻿using System.IO;
+using System.Net;
+using System.Net.Http.Headers;
+
+namespace Docker.DotNet
+{
+    internal class DockerApiStreamedResponse
+    {
+        public HttpStatusCode StatusCode { get; private set; }
+
+        public Stream Body { get; private set; }
+
+        public HttpResponseHeaders Headers { get; private set; }
+
+        public DockerApiStreamedResponse(HttpStatusCode statusCode, Stream body, HttpResponseHeaders headers)
+        {
+            this.StatusCode = statusCode;
+            this.Body = body;
+            this.Headers = headers;
+        }
+    }
+}

--- a/Docker.DotNet/IContainerOperations.cs
+++ b/Docker.DotNet/IContainerOperations.cs
@@ -42,7 +42,7 @@ namespace Docker.DotNet
 
         Task<Stream> CopyFromContainerAsync(string id, CopyFromContainerParameters parameters, CancellationToken cancellationToken);
 
-        Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statsOnly, CancellationToken cancellationToken);
+        Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statOnly, CancellationToken cancellationToken);
 
         Task ExtractArchiveToContainerAsync(string id, ExtractArchiveToContainerParameters parameters, Stream stream, CancellationToken cancellationToken);
     }

--- a/Docker.DotNet/IContainerOperations.cs
+++ b/Docker.DotNet/IContainerOperations.cs
@@ -41,5 +41,9 @@ namespace Docker.DotNet
         Task<Stream> GetContainerLogsAsync(string id, GetContainerLogsParameters parameters, CancellationToken cancellationToken);
 
         Task<Stream> CopyFromContainerAsync(string id, CopyFromContainerParameters parameters, CancellationToken cancellationToken);
+
+        Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statsOnly, CancellationToken cancellationToken);
+
+        Task ExtractArchiveToContainerAsync(string id, ExtractArchiveToContainerParameters parameters, Stream stream, CancellationToken cancellationToken);
     }
 }

--- a/Docker.DotNet/Models/ContainerPathStat.cs
+++ b/Docker.DotNet/Models/ContainerPathStat.cs
@@ -4,7 +4,7 @@ using System.Runtime.Serialization;
 namespace Docker.DotNet.Models
 {
     [DataContract]
-    public class ContainerPathStats
+    public class ContainerPathStat
     {
         [DataMember(Name = "Name")]
         public string Name { get; set; }

--- a/Docker.DotNet/Models/ContainerPathStats.cs
+++ b/Docker.DotNet/Models/ContainerPathStats.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Docker.DotNet.Models
+{
+    [DataContract]
+    public class ContainerPathStats
+    {
+        [DataMember(Name = "Name")]
+        public string Name { get; set; }
+
+        [DataMember(Name = "Size")]
+        public int Size { get; set; }
+
+        [DataMember(Name = "Mode")]
+        public int Mode { get; set; }
+
+        [DataMember(Name = "MTime")]
+        public DateTime ModifiedTime { get; set; }
+
+        [DataMember(Name = "LinkTarget")]
+        public string LinkTarget { get; set; } 
+    }
+}

--- a/Docker.DotNet/Models/ExtractArchiveToContainerParameters.cs
+++ b/Docker.DotNet/Models/ExtractArchiveToContainerParameters.cs
@@ -6,6 +6,6 @@
         public string Path { get; set; }
 
         [QueryStringParameter("noOverwriteDirNonDir", false, typeof(BoolQueryStringConverter))]
-        public bool NoOverwriteDirNonDir { get; set; }
+        public bool? NoOverwriteDirNonDir { get; set; }
     }
 }

--- a/Docker.DotNet/Models/ExtractArchiveToContainerParameters.cs
+++ b/Docker.DotNet/Models/ExtractArchiveToContainerParameters.cs
@@ -1,0 +1,11 @@
+﻿namespace Docker.DotNet.Models
+{
+    public class ExtractArchiveToContainerParameters
+    {
+        [QueryStringParameter("path", true)]
+        public string Path { get; set; }
+
+        [QueryStringParameter("noOverwriteDirNonDir", false, typeof(BoolQueryStringConverter))]
+        public bool NoOverwriteDirNonDir { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/GetArchiveFromContainerParameters.cs
+++ b/Docker.DotNet/Models/GetArchiveFromContainerParameters.cs
@@ -1,0 +1,8 @@
+﻿namespace Docker.DotNet.Models
+{
+    public class GetArchiveFromContainerParameters
+    {
+        [QueryStringParameter("path", true)]
+        public string Path { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/GetArchiveFromContainerResponse.cs
+++ b/Docker.DotNet/Models/GetArchiveFromContainerResponse.cs
@@ -1,0 +1,11 @@
+﻿using System.IO;
+
+namespace Docker.DotNet.Models
+{
+    public class GetArchiveFromContainerResponse
+    {
+        public ContainerPathStats Stats { get; set; }
+
+        public Stream Stream { get; set; }
+    }
+}

--- a/Docker.DotNet/Models/GetArchiveFromContainerResponse.cs
+++ b/Docker.DotNet/Models/GetArchiveFromContainerResponse.cs
@@ -4,7 +4,7 @@ namespace Docker.DotNet.Models
 {
     public class GetArchiveFromContainerResponse
     {
-        public ContainerPathStats Stats { get; set; }
+        public ContainerPathStat Stat { get; set; }
 
         public Stream Stream { get; set; }
     }

--- a/Docker.DotNet/Models/HostConfig.cs
+++ b/Docker.DotNet/Models/HostConfig.cs
@@ -12,6 +12,9 @@ namespace Docker.DotNet.Models
         [DataMember(Name = "Links")]
         public IList<string> Links { get; set; }
 
+        [DataMember(Name = "GroupAdd")]
+        public IList<string> GroupAdd { get; set; }
+
         [DataMember(Name = "ContainerIDFile")]
         public string ContainerIdFile { get; set; }
 


### PR DESCRIPTION
This is to introduce api changes introduced in 1.20.
* `GET /containers/(id)/archive` get an archive of filesystem content from a container.
* `PUT /containers/(id)/archive` upload an archive of content to be extracted to an existing directory inside a container’s filesystem.
* `POST /containers/(id)/copy` is deprecated in favor of the above `archive` endpoint which can be used to download files and directories from a container.
* The `hostConfig` option now accepts the field `GroupAdd`, which specifies a list of additional groups that the container process will run as.

Most of it is pretty similar to existing methods, I had to add an extra method to dockerclient so I could retrieve the stream along with its headers. One thing I wasn't quote sure about was whether the HEAD request to the archive endpoint should be a separate method, the difference between GET and HEAD is that HEAD won't return a stream.
