### PR TITLE
Temporarily removing support for netstandard1.3

### DIFF
--- a/Docker.DotNet.BasicAuth/project.json
+++ b/Docker.DotNet.BasicAuth/project.json
@@ -8,22 +8,6 @@
     "win10-x86": {}
   },
   "frameworks": {
-    "netstandard1.3": {
-      "imports": [
-        "dotnet",
-        "netcore50",
-        "uap10"
-      ],
-      "compilationOptions": {
-        "define": [
-          "netstandard"
-        ]
-      },
-      "dependencies": {
-        "System.Runtime": "4.0.20",
-        "System.Text.Encoding": "4.0.10"
-      }
-    },
     "net46": {
       "frameworkAssemblies": {
         "System.Runtime": "",

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -8,28 +8,6 @@
     "win10-x86": {}
   },
   "frameworks": {
-    "netstandard1.3": {
-      "imports": [
-        "dotnet",
-        "netcore50",
-        "uap10"
-      ],
-      "dependencies": {
-        "System.Collections": "4.0.10",
-        "System.IO": "4.0.10",
-        "System.IO.FileSystem": "4.0.0",
-        "System.Linq": "4.0.0",
-        "System.Net.Http": "4.0.0",
-        "System.Reflection": "4.0.10",
-        "System.Reflection.Extensions": "4.0.0",
-        "System.Reflection.TypeExtensions": "4.0.0",
-        "System.Runtime": "4.0.20",
-        "System.Runtime.Serialization.Primitives": "4.1.0",
-        "System.Text.Encoding": "4.0.10",
-        "System.Text.Encoding.Extensions": "4.0.10",
-        "System.Threading.Tasks": "4.0.10"
-      }
-    },
     "net46": {
       "frameworkAssemblies": {
         "System.Net.Http": "",


### PR DESCRIPTION
@jterry75 @ahmetalpbalkan @jstarks 
We've hit an issue compiling for netstandard1.3 using the latest version of the dotnet CLI (reported here: https://github.com/dotnet/cli/issues/2739). The current mechanism used to incorrectly report success during compile, but required runtime references couldn't be found with the latest dotnet CLI.  Until we have a resolution to the issue or better guidance on how to compile for DNXCore, it's safer in the short term to remove that build target.