### PR TITLE
Resolves: #59

### DIFF
--- a/Docker.DotNet/Models/Address.Generated.cs
+++ b/Docker.DotNet/Models/Address.Generated.cs
@@ -9,6 +9,6 @@ namespace Docker.DotNet.Models
         public string Addr { get; set; }
 
         [DataMember(Name = "PrefixLen")]
-        public int PrefixLen { get; set; }
+        public long PrefixLen { get; set; }
     }
 }

--- a/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
+++ b/Docker.DotNet/Models/ContainerInspectResponse.Generated.cs
@@ -76,7 +76,7 @@ namespace Docker.DotNet.Models
         public string Name { get; set; }
 
         [DataMember(Name = "RestartCount")]
-        public int RestartCount { get; set; }
+        public long RestartCount { get; set; }
 
         [DataMember(Name = "Driver")]
         public string Driver { get; set; }

--- a/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
+++ b/Docker.DotNet/Models/ContainerJSONBase.Generated.cs
@@ -43,7 +43,7 @@ namespace Docker.DotNet.Models
         public string Name { get; set; }
 
         [DataMember(Name = "RestartCount")]
-        public int RestartCount { get; set; }
+        public long RestartCount { get; set; }
 
         [DataMember(Name = "Driver")]
         public string Driver { get; set; }

--- a/Docker.DotNet/Models/ContainerNode.Generated.cs
+++ b/Docker.DotNet/Models/ContainerNode.Generated.cs
@@ -19,10 +19,10 @@ namespace Docker.DotNet.Models
         public string Name { get; set; }
 
         [DataMember(Name = "Cpus")]
-        public int Cpus { get; set; }
+        public long Cpus { get; set; }
 
         [DataMember(Name = "Memory")]
-        public int Memory { get; set; }
+        public long Memory { get; set; }
 
         [DataMember(Name = "Labels")]
         public IDictionary<string, string> Labels { get; set; }

--- a/Docker.DotNet/Models/ContainerState.Generated.cs
+++ b/Docker.DotNet/Models/ContainerState.Generated.cs
@@ -24,10 +24,10 @@ namespace Docker.DotNet.Models
         public bool Dead { get; set; }
 
         [DataMember(Name = "Pid")]
-        public int Pid { get; set; }
+        public long Pid { get; set; }
 
         [DataMember(Name = "ExitCode")]
-        public int ExitCode { get; set; }
+        public long ExitCode { get; set; }
 
         [DataMember(Name = "Error")]
         public string Error { get; set; }

--- a/Docker.DotNet/Models/ContainerWaitResponse.Generated.cs
+++ b/Docker.DotNet/Models/ContainerWaitResponse.Generated.cs
@@ -6,6 +6,6 @@ namespace Docker.DotNet.Models
     public class ContainerWaitResponse // (types.ContainerWaitResponse)
     {
         [DataMember(Name = "StatusCode")]
-        public int StatusCode { get; set; }
+        public long StatusCode { get; set; }
     }
 }

--- a/Docker.DotNet/Models/ContainersListParameters.Generated.cs
+++ b/Docker.DotNet/Models/ContainersListParameters.Generated.cs
@@ -24,7 +24,7 @@ namespace Docker.DotNet.Models
         public string Before { get; set; }
 
         [QueryStringParameter("limit", false)]
-        public int? Limit { get; set; }
+        public long? Limit { get; set; }
 
         [QueryStringParameter("filters", false)]
         public Args Filter { get; set; }

--- a/Docker.DotNet/Models/DefaultNetworkSettings.Generated.cs
+++ b/Docker.DotNet/Models/DefaultNetworkSettings.Generated.cs
@@ -15,13 +15,13 @@ namespace Docker.DotNet.Models
         public string GlobalIPv6Address { get; set; }
 
         [DataMember(Name = "GlobalIPv6PrefixLen")]
-        public int GlobalIPv6PrefixLen { get; set; }
+        public long GlobalIPv6PrefixLen { get; set; }
 
         [DataMember(Name = "IPAddress")]
         public string IPAddress { get; set; }
 
         [DataMember(Name = "IPPrefixLen")]
-        public int IPPrefixLen { get; set; }
+        public long IPPrefixLen { get; set; }
 
         [DataMember(Name = "IPv6Gateway")]
         public string IPv6Gateway { get; set; }

--- a/Docker.DotNet/Models/EndpointSettings.Generated.cs
+++ b/Docker.DotNet/Models/EndpointSettings.Generated.cs
@@ -28,7 +28,7 @@ namespace Docker.DotNet.Models
         public string IPAddress { get; set; }
 
         [DataMember(Name = "IPPrefixLen")]
-        public int IPPrefixLen { get; set; }
+        public long IPPrefixLen { get; set; }
 
         [DataMember(Name = "IPv6Gateway")]
         public string IPv6Gateway { get; set; }
@@ -37,7 +37,7 @@ namespace Docker.DotNet.Models
         public string GlobalIPv6Address { get; set; }
 
         [DataMember(Name = "GlobalIPv6PrefixLen")]
-        public int GlobalIPv6PrefixLen { get; set; }
+        public long GlobalIPv6PrefixLen { get; set; }
 
         [DataMember(Name = "MacAddress")]
         public string MacAddress { get; set; }

--- a/Docker.DotNet/Models/HostConfig.Generated.cs
+++ b/Docker.DotNet/Models/HostConfig.Generated.cs
@@ -102,7 +102,7 @@ namespace Docker.DotNet.Models
         public IList<string> Links { get; set; }
 
         [DataMember(Name = "OomScoreAdj")]
-        public int OomScoreAdj { get; set; }
+        public long OomScoreAdj { get; set; }
 
         [DataMember(Name = "PidMode")]
         public string PidMode { get; set; }
@@ -138,7 +138,7 @@ namespace Docker.DotNet.Models
         public IDictionary<string, string> Sysctls { get; set; }
 
         [DataMember(Name = "ConsoleSize")]
-        public int[] ConsoleSize { get; set; }
+        public long[] ConsoleSize { get; set; }
 
         [DataMember(Name = "Isolation")]
         public string Isolation { get; set; }

--- a/Docker.DotNet/Models/ImageSearchResponse.Generated.cs
+++ b/Docker.DotNet/Models/ImageSearchResponse.Generated.cs
@@ -6,7 +6,7 @@ namespace Docker.DotNet.Models
     public class ImageSearchResponse // (registry.SearchResult)
     {
         [DataMember(Name = "star_count")]
-        public int StarCount { get; set; }
+        public long StarCount { get; set; }
 
         [DataMember(Name = "is_official")]
         public bool IsOfficial { get; set; }

--- a/Docker.DotNet/Models/NetworkSettings.Generated.cs
+++ b/Docker.DotNet/Models/NetworkSettings.Generated.cs
@@ -51,7 +51,7 @@ namespace Docker.DotNet.Models
         public string LinkLocalIPv6Address { get; set; }
 
         [DataMember(Name = "LinkLocalIPv6PrefixLen")]
-        public int LinkLocalIPv6PrefixLen { get; set; }
+        public long LinkLocalIPv6PrefixLen { get; set; }
 
         [DataMember(Name = "Ports")]
         public IDictionary<string, IList<PortBinding>> Ports { get; set; }
@@ -75,13 +75,13 @@ namespace Docker.DotNet.Models
         public string GlobalIPv6Address { get; set; }
 
         [DataMember(Name = "GlobalIPv6PrefixLen")]
-        public int GlobalIPv6PrefixLen { get; set; }
+        public long GlobalIPv6PrefixLen { get; set; }
 
         [DataMember(Name = "IPAddress")]
         public string IPAddress { get; set; }
 
         [DataMember(Name = "IPPrefixLen")]
-        public int IPPrefixLen { get; set; }
+        public long IPPrefixLen { get; set; }
 
         [DataMember(Name = "IPv6Gateway")]
         public string IPv6Gateway { get; set; }

--- a/Docker.DotNet/Models/NetworkSettingsBase.Generated.cs
+++ b/Docker.DotNet/Models/NetworkSettingsBase.Generated.cs
@@ -19,7 +19,7 @@ namespace Docker.DotNet.Models
         public string LinkLocalIPv6Address { get; set; }
 
         [DataMember(Name = "LinkLocalIPv6PrefixLen")]
-        public int LinkLocalIPv6PrefixLen { get; set; }
+        public long LinkLocalIPv6PrefixLen { get; set; }
 
         [DataMember(Name = "Ports")]
         public IDictionary<string, IList<PortBinding>> Ports { get; set; }

--- a/Docker.DotNet/Models/PidsStats.Generated.cs
+++ b/Docker.DotNet/Models/PidsStats.Generated.cs
@@ -7,5 +7,8 @@ namespace Docker.DotNet.Models
     {
         [DataMember(Name = "current")]
         public ulong Current { get; set; }
+
+        [DataMember(Name = "limit")]
+        public ulong Limit { get; set; }
     }
 }

--- a/Docker.DotNet/Models/Port.Generated.cs
+++ b/Docker.DotNet/Models/Port.Generated.cs
@@ -9,10 +9,10 @@ namespace Docker.DotNet.Models
         public string IP { get; set; }
 
         [DataMember(Name = "PrivatePort")]
-        public int PrivatePort { get; set; }
+        public long PrivatePort { get; set; }
 
         [DataMember(Name = "PublicPort")]
-        public int PublicPort { get; set; }
+        public long PublicPort { get; set; }
 
         [DataMember(Name = "Type")]
         public string Type { get; set; }

--- a/Docker.DotNet/Models/RestartPolicy.Generated.cs
+++ b/Docker.DotNet/Models/RestartPolicy.Generated.cs
@@ -9,6 +9,6 @@ namespace Docker.DotNet.Models
         public RestartPolicyKind Name { get; set; }
 
         [DataMember(Name = "MaximumRetryCount")]
-        public int MaximumRetryCount { get; set; }
+        public long MaximumRetryCount { get; set; }
     }
 }

--- a/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
+++ b/Docker.DotNet/Models/SystemInfoResponse.Generated.cs
@@ -10,19 +10,19 @@ namespace Docker.DotNet.Models
         public string ID { get; set; }
 
         [DataMember(Name = "Containers")]
-        public int Containers { get; set; }
+        public long Containers { get; set; }
 
         [DataMember(Name = "ContainersRunning")]
-        public int ContainersRunning { get; set; }
+        public long ContainersRunning { get; set; }
 
         [DataMember(Name = "ContainersPaused")]
-        public int ContainersPaused { get; set; }
+        public long ContainersPaused { get; set; }
 
         [DataMember(Name = "ContainersStopped")]
-        public int ContainersStopped { get; set; }
+        public long ContainersStopped { get; set; }
 
         [DataMember(Name = "Images")]
-        public int Images { get; set; }
+        public long Images { get; set; }
 
         [DataMember(Name = "Driver")]
         public string Driver { get; set; }
@@ -70,13 +70,13 @@ namespace Docker.DotNet.Models
         public bool Debug { get; set; }
 
         [DataMember(Name = "NFd")]
-        public int NFd { get; set; }
+        public long NFd { get; set; }
 
         [DataMember(Name = "OomKillDisable")]
         public bool OomKillDisable { get; set; }
 
         [DataMember(Name = "NGoroutines")]
-        public int NGoroutines { get; set; }
+        public long NGoroutines { get; set; }
 
         [DataMember(Name = "SystemTime")]
         public string SystemTime { get; set; }
@@ -91,7 +91,7 @@ namespace Docker.DotNet.Models
         public string CgroupDriver { get; set; }
 
         [DataMember(Name = "NEventsListener")]
-        public int NEventsListener { get; set; }
+        public long NEventsListener { get; set; }
 
         [DataMember(Name = "KernelVersion")]
         public string KernelVersion { get; set; }
@@ -112,7 +112,7 @@ namespace Docker.DotNet.Models
         public ServiceConfig RegistryConfig { get; set; }
 
         [DataMember(Name = "NCPU")]
-        public int NCPU { get; set; }
+        public long NCPU { get; set; }
 
         [DataMember(Name = "MemTotal")]
         public long MemTotal { get; set; }


### PR DESCRIPTION
1. Fixes a bug where in Go int and uint are converted to the runtime type
size not the standard 32bit like in C#. This updates the generator to
output int and uint as long and ulong instead so we dont get type
mismatches from the service.

Signed-off-by: Justin Terry <juterry@microsoft.com>