### PR TITLE
Handle deserializing null values to defaults in C#

### DIFF
--- a/Docker.DotNet/JsonSerializer.cs
+++ b/Docker.DotNet/JsonSerializer.cs
@@ -4,15 +4,23 @@ using Newtonsoft.Json.Converters;
 namespace Docker.DotNet
 {
     /// <summary>
-    /// Facade for <see cref="Newtonsoft.Json.JsonConvert"/>.
+    /// Facade for <see cref="JsonConvert"/>.
     /// </summary>
     internal class JsonSerializer
     {
-        private Newtonsoft.Json.JsonConverter[] Converters { get; set; }
+        private JsonConverter[] Converters { get; }
+
+        static JsonSerializer()
+        {
+            JsonConvert.DefaultSettings = () => new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore
+            };
+        }
 
         public JsonSerializer()
         {
-            this.Converters = new Newtonsoft.Json.JsonConverter[]
+            this.Converters = new JsonConverter[]
             {
                 new JsonIso8601AndUnixEpochDateConverter(),
                 new JsonVersionConverter(),


### PR DESCRIPTION
Resolves an issue where the Docker daemon might not send an actual value
that can be deserialized into the strongly typed C# model. In go values
like this are given the default value of the type itself but it does not
cause a failure in deserialization.

Resolves: #61

Signed-off-by: Justin Terry <juterry@microsoft.com>