### PR TITLE
Fixes .NET Core,uap10,netstandard builds.

### DIFF
--- a/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
+++ b/Docker.DotNet.BasicAuth/BasicAuthCredentials.cs
@@ -15,7 +15,7 @@ namespace Docker.DotNet.BasicAuth
             return new BasicAuthHandler(_username, _password, innerHandler);
         }
 
-#if !netstandard
+#if !netstandard1_3
         public BasicAuthCredentials(SecureString username, SecureString password, bool isTls = false)
             : this(new MaybeSecureString(username), new MaybeSecureString(password), isTls)
         {

--- a/Docker.DotNet.BasicAuth/MaybeSecureString.cs
+++ b/Docker.DotNet.BasicAuth/MaybeSecureString.cs
@@ -6,7 +6,7 @@ namespace Docker.DotNet.BasicAuth
 {
     internal class MaybeSecureString : IDisposable
     {
-#if !netstandard
+#if !netstandard1_3
 
         public SecureString Value { get; }
 

--- a/Docker.DotNet.BasicAuth/project.json
+++ b/Docker.DotNet.BasicAuth/project.json
@@ -3,11 +3,20 @@
   "dependencies": {
     "Docker.DotNet": "2.124.0"
   },
-  "runtimes": {
-    "win10-x64": {},
-    "win10-x86": {}
-  },
   "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "netcoreapp",
+        "uap10",
+        "portable-dnxcore50+net45+win8+wp8+wpa81"
+      ],
+      "buildOptions": {
+        "define": [
+          "netstandard1_3"
+        ]
+      }
+    },
     "net46": {
       "frameworkAssemblies": {
         "System.Runtime": "",

--- a/Docker.DotNet.X509/CertificateCredentials.cs
+++ b/Docker.DotNet.X509/CertificateCredentials.cs
@@ -1,7 +1,11 @@
-﻿using System.Net;
+﻿#if !netstandard1_3
+using System.Net;
+#endif
+
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using Microsoft.Net.Http.Client;
+using System.Net.Security;
 
 namespace Docker.DotNet.X509
 {
@@ -13,6 +17,8 @@ namespace Docker.DotNet.X509
         {
             _certificate = clientCertificate;
         }
+        
+        public RemoteCertificateValidationCallback ServerCertificateValidationCallback { get; set; }
 
         public override HttpMessageHandler GetHandler(HttpMessageHandler innerHandler)
         {
@@ -22,7 +28,14 @@ namespace Docker.DotNet.X509
                 _certificate
             };
 
-            handler.ServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;
+            
+#if !netstandard1_3
+            if (this.ServerCertificateValidationCallback == null)
+            {
+                handler.ServerCertificateValidationCallback = ServicePointManager.ServerCertificateValidationCallback;
+            }
+#endif
+            handler.ServerCertificateValidationCallback = this.ServerCertificateValidationCallback;
             return handler;
         }
 

--- a/Docker.DotNet.X509/project.json
+++ b/Docker.DotNet.X509/project.json
@@ -5,6 +5,22 @@
         "Docker.DotNet": "2.124.0"
     },
     "frameworks": {
+        "netstandard1.3": {
+            "buildOptions": {
+                "define": [
+                    "netstandard1_3"
+                ]
+            },
+            "imports": [
+                "dotnet5.4",
+                "netcoreapp",
+                "uap10",
+                "portable-dnxcore50+net45+win8+wp8+wpa81"
+            ],
+            "dependencies": {
+                "System.Security.Cryptography.X509Certificates": "4.0.0-beta-23516"
+            }
+        },
         "net46": {
             "frameworkAssemblies": {
                 "System.Net.Http": "",

--- a/Docker.DotNet/DockerClient.cs
+++ b/Docker.DotNet/DockerClient.cs
@@ -67,7 +67,7 @@ namespace Docker.DotNet
                     }
 
                     var segments = uri.Segments;
-                    if (segments.Length != 3 || !segments[1].Equals("pipe/", StringComparison.InvariantCultureIgnoreCase))
+                    if (segments.Length != 3 || !segments[1].Equals("pipe/", StringComparison.OrdinalIgnoreCase))
                     {
                         throw new ArgumentException($"{Configuration.EndpointBaseUri} is not a valid npipe URI");
                     }

--- a/Docker.DotNet/EnumerableQueryStringConverter.cs
+++ b/Docker.DotNet/EnumerableQueryStringConverter.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace Docker.DotNet
@@ -13,7 +14,7 @@ namespace Docker.DotNet
     {
         public bool CanConvert(Type t)
         {
-            return typeof (IEnumerable).IsAssignableFrom(t);
+            return typeof (IEnumerable).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo());
         }
 
         public string[] Convert(object o)

--- a/Docker.DotNet/MapQueryStringConverter.cs
+++ b/Docker.DotNet/MapQueryStringConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Diagnostics;
+using System.Reflection;
 using Newtonsoft.Json;
 
 namespace Docker.DotNet
@@ -9,7 +10,7 @@ namespace Docker.DotNet
     {
         public bool CanConvert(Type t)
         {
-            return typeof (IList).IsAssignableFrom(t) || typeof (IDictionary).IsAssignableFrom(t);
+            return typeof (IList).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo()) || typeof (IDictionary).GetTypeInfo().IsAssignableFrom(t.GetTypeInfo());
         }
 
         public string[] Convert(object o)

--- a/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Net.Http.Client
             {
                 if (_proxy == null)
                 {
-                    _proxy = WebRequest.GetSystemWebProxy();
+                    _proxy = WebRequest.DefaultWebProxy;
                 }
                 return _proxy;
             }

--- a/Docker.DotNet/QueryStringParameterAttribute.cs
+++ b/Docker.DotNet/QueryStringParameterAttribute.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+using System.Reflection;
 
 namespace Docker.DotNet
 {

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -3,11 +3,29 @@
   "dependencies": {
     "Newtonsoft.Json": "8.0.3"
   },
-  "runtimes": {
-    "win10-x64": {},
-    "win10-x86": {}
-  },
   "frameworks": {
+    "netstandard1.3": {
+      "imports": [
+        "dotnet5.4",
+        "netcoreapp",
+        "uap10",
+        "portable-dnxcore50+net45+win8+wp8+wpa81"
+      ],
+      "dependencies": {
+        "System.IO": "4.0.11-rc3-23829",
+        "System.IO.Pipes": "4.0.0-beta-23516",
+        "System.Linq": "4.0.1-rc3-23829",
+        "System.Net.Http": "4.0.1-rc3-23829",
+        "System.Net.Requests": "4.0.11-beta-23516",
+        "System.Net.Security": "4.0.0-beta-23516",
+        "System.Net.Sockets": "4.1.0-rc3-23829",
+        "System.Text.Encoding": "4.0.11-rc3-23829",
+        "System.Reflection.Extensions": "4.0.1-rc3-23829",
+        "System.Reflection.TypeExtensions": "4.1.0-rc3-23829",
+        "System.Runtime": "4.0.21-rc3-23829",
+        "System.Runtime.Serialization.Primitives": "4.1.0-rc3-23829"
+      }
+    },
     "net46": {
       "frameworkAssemblies": {
         "System.Net.Http": "",

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="nuget.org" value="https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" />
+  </packageSources>
+  <packageRestore>
+    <add key="enabled" value="True" />
+    <add key="automatic" value="True" />
+  </packageRestore>
+  <bindingRedirects>
+    <add key="skip" value="False" />
+  </bindingRedirects>
+  <activePackageSource>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </activePackageSource>
+</configuration>


### PR DESCRIPTION
Makes the changes required in order to release Docker.DotNet for
UAP10,NetCoreApp, and NetStandard.

Resolves: #56

Signed-off-by: Justin Terry <juterry@microsoft.com>