### PR TITLE
Support attaching to Docker container input/output

### DIFF
--- a/Docker.DotNet/DockerPipeStream.cs
+++ b/Docker.DotNet/DockerPipeStream.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.IO.Pipes;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Net.Http.Client;
+using Microsoft.Win32.SafeHandles;
+
+namespace Docker.DotNet
+{
+    internal class DockerPipeStream : WriteClosableStream
+    {
+        private PipeStream _stream;
+        private EventWaitHandle _event = new EventWaitHandle(false, EventResetMode.AutoReset);
+
+        public DockerPipeStream(PipeStream stream)
+        {
+            _stream = stream;
+        }
+
+        public override bool CanCloseWrite => true;
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length
+        {
+            get { throw new NotImplementedException(); }
+        }
+
+        public override long Position
+        {
+            get { throw new NotImplementedException(); }
+
+            set { throw new NotImplementedException(); }
+        }
+
+        [DllImport("api-ms-win-core-file-l1-1-0.dll", SetLastError = true)]
+        private static extern int WriteFile(SafeHandle handle, IntPtr buffer, int numBytesToWrite, IntPtr numBytesWritten, ref NativeOverlapped overlapped);
+
+        [DllImport("api-ms-win-core-io-l1-1-0.dll", SetLastError = true)]
+        private static extern int GetOverlappedResult(SafeHandle handle, ref NativeOverlapped overlapped, out int numBytesWritten, int wait);
+
+        public override void CloseWrite()
+        {
+            // The Docker daemon expects a write of zero bytes to signal the end of writes. Use native
+            // calls to achieve this since CoreCLR ignores a zero-byte write.
+            var overlapped = new NativeOverlapped();
+            SafeWaitHandle handle;
+#if NET45
+            handle = _event.SafeWaitHandle;
+#else
+            handle = _event.GetSafeWaitHandle();
+#endif
+            // Set the low bit to tell Windows not to send the result of this IO to the
+            // completion port.
+            overlapped.EventHandle = (IntPtr)(handle.DangerousGetHandle().ToInt64() | 1);
+            if (WriteFile(_stream.SafePipeHandle, IntPtr.Zero, 0, IntPtr.Zero, ref overlapped) == 0)
+            {
+                const int ERROR_IO_PENDING = 997;
+                if (Marshal.GetLastWin32Error() == ERROR_IO_PENDING)
+                {
+                    int written;
+                    if (GetOverlappedResult(_stream.SafePipeHandle, ref overlapped, out written, 1) == 0)
+                    {
+                        Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                    }
+                }
+                else
+                {
+                    Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+                }
+            }
+        }
+
+        public override void Flush()
+        {
+            throw new NotImplementedException();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _stream.Read(buffer, offset, count);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _stream.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _stream.Write(buffer, offset, count);
+        }
+
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _stream.Dispose();
+                _event.Dispose();
+            }
+        }
+    }
+}

--- a/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -28,20 +28,6 @@ namespace Docker.DotNet
             this.Client = client;
         }
 
-        public async Task<MultiplexedStream> AttachContainerAsync(string id, bool tty, ContainerAttachParameters parameters, CancellationToken cancellationToken)
-        {
-            var path = $"containers/{id}/attach";
-            var queryParameters = new QueryString<ContainerAttachParameters>(parameters);
-            var stream = await this.Client.MakeRequestForHijackedStreamAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, queryParameters, null, null, cancellationToken).ConfigureAwait(false);
-            if (!stream.CanCloseWrite)
-            {
-                stream.Dispose();
-                throw new NotSupportedException("Cannot shutdown write on this transport");
-            }
-
-            return new MultiplexedStream(stream, !tty);
-        }
-
         public async Task<IList<ContainerListResponse>> ListContainersAsync(ContainersListParameters parameters)
         {
             if (parameters == null)
@@ -63,7 +49,7 @@ namespace Docker.DotNet
             }
 
             var path = $"containers/{id}/json";
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerInspectResponse>(response.Body);
         }
 
@@ -83,7 +69,7 @@ namespace Docker.DotNet
 
             var path = "containers/create";
             var data = new JsonRequestContent<CreateContainerParameters>(parameters, this.Client.JsonSerializer);
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, qs, data).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, qs, data).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<CreateContainerResponse>(response.Body);
         }
 
@@ -95,7 +81,7 @@ namespace Docker.DotNet
             }
 
             var path = $"containers/{id}/export";
-            return this.Client.MakeRequestForStreamAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null, null, null, cancellationToken);
+            return this.Client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null, null, null, cancellationToken);
         }
 
         public async Task<ContainerProcessesResponse> ListProcessesAsync(string id, ContainerListProcessesParameters parameters)
@@ -112,7 +98,7 @@ namespace Docker.DotNet
 
             var path = $"containers/{id}/top";
             IQueryString queryParameters = new QueryString<ContainerListProcessesParameters>(parameters);
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, queryParameters).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerProcessesResponse>(response.Body);
         }
 
@@ -124,7 +110,7 @@ namespace Docker.DotNet
             }
 
             var path = $"containers/{id}/changes";
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, null).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, null).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerFileSystemChangeResponse[]>(response.Body);
         }
 
@@ -141,7 +127,7 @@ namespace Docker.DotNet
             {
                 data = new JsonRequestContent<HostConfig>(hostConfig, this.Client.JsonSerializer);
             }
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, data).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, data).ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotModified;
         }
 
@@ -179,7 +165,7 @@ namespace Docker.DotNet
             IQueryString queryParameters = new QueryString<ContainerStopParameters>(parameters);
             // since specified wait timespan can be greater than HttpClient's default, we set the
             // client timeout to infinite and provide a cancellation token.
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, queryParameters, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
             return response.StatusCode != HttpStatusCode.NotModified;
         }
 
@@ -200,7 +186,7 @@ namespace Docker.DotNet
             IQueryString queryParameters = new QueryString<ConatinerRestartParameters>(parameters);
             // since specified wait timespan can be greater than HttpClient's default, we set the
             // client timeout to infinite and provide a cancellation token.
-            return this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, queryParameters, null, new TimeSpan?(new TimeSpan(Timeout.Infinite)), cancellationToken);
+            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, new TimeSpan?(new TimeSpan(Timeout.Infinite)), cancellationToken);
         }
 
         public Task KillContainerAsync(string id, ContainerKillParameters parameters)
@@ -217,7 +203,7 @@ namespace Docker.DotNet
 
             var path = $"containers/{id}/kill";
             IQueryString queryParameters = new QueryString<ContainerKillParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, queryParameters);
+            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters);
         }
 
         public Task PauseContainerAsync(string id)
@@ -228,7 +214,7 @@ namespace Docker.DotNet
             }
 
             var path = $"containers/{id}/pause";
-            return this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null);
+            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null);
         }
 
         public Task UnpauseContainerAsync(string id)
@@ -239,7 +225,7 @@ namespace Docker.DotNet
             }
 
             var path = $"containers/{id}/unpause";
-            return this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null);
+            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null);
         }
 
         public async Task<ContainerWaitResponse> WaitContainerAsync(string id, CancellationToken cancellationToken)
@@ -250,7 +236,7 @@ namespace Docker.DotNet
             }
 
             var path = $"containers/{id}/wait";
-            var response = await this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Post, path, null, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
+            var response = await this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, null, null, new TimeSpan(Timeout.Infinite), cancellationToken).ConfigureAwait(false);
             return this.Client.JsonSerializer.DeserializeObject<ContainerWaitResponse>(response.Body);
         }
 
@@ -268,7 +254,7 @@ namespace Docker.DotNet
 
             var path = $"containers/{id}";
             IQueryString queryParameters = new QueryString<ContainerRemoveParameters>(parameters);
-            return this.Client.MakeRequestAsync(new[] {NoSuchContainerHandler}, HttpMethod.Delete, path, queryParameters);
+            return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Delete, path, queryParameters);
         }
 
         public Task<Stream> GetContainerLogsAsync(string id, ContainerLogsParameters parameters, CancellationToken cancellationToken)
@@ -285,7 +271,7 @@ namespace Docker.DotNet
 
             var path = $"containers/{id}/logs";
             IQueryString queryParameters = new QueryString<ContainerLogsParameters>(parameters);
-            return this.Client.MakeRequestForStreamAsync(new[] {NoSuchContainerHandler}, HttpMethod.Get, path, queryParameters, null, cancellationToken);
+            return this.Client.MakeRequestForStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Get, path, queryParameters, null, cancellationToken);
         }
 
         public async Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statOnly, CancellationToken cancellationToken)
@@ -340,6 +326,30 @@ namespace Docker.DotNet
             var path = $"containers/{id}/archive";
 
             return this.Client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Put, path, queryParameters, data, null, cancellationToken);
+        }
+
+        public async Task<MultiplexedStream> AttachContainerAsync(string id, bool tty, ContainerAttachParameters parameters, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                throw new ArgumentNullException(nameof(id));
+            }
+
+            if (parameters == null)
+            {
+                throw new ArgumentNullException(nameof(parameters));
+            }
+
+            var path = $"containers/{id}/attach";
+            var queryParameters = new QueryString<ContainerAttachParameters>(parameters);
+            var stream = await this.Client.MakeRequestForHijackedStreamAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, path, queryParameters, null, null, cancellationToken).ConfigureAwait(false);
+            if (!stream.CanCloseWrite)
+            {
+                stream.Dispose();
+                throw new NotSupportedException("Cannot shutdown write on this transport");
+            }
+
+            return new MultiplexedStream(stream, !tty);
         }
     }
 }

--- a/Docker.DotNet/Endpoints/IContainerOperations.cs
+++ b/Docker.DotNet/Endpoints/IContainerOperations.cs
@@ -43,5 +43,6 @@ namespace Docker.DotNet
         Task<GetArchiveFromContainerResponse> GetArchiveFromContainerAsync(string id, GetArchiveFromContainerParameters parameters, bool statOnly, CancellationToken cancellationToken);
 
         Task ExtractArchiveToContainerAsync(string id, ContainerPathStatParameters parameters, Stream stream, CancellationToken cancellationToken);
+        Task<MultiplexedStream> AttachContainerAsync(string id, bool tty, ContainerAttachParameters parameters, CancellationToken cancellationToken);
     }
 }

--- a/Docker.DotNet/Microsoft.Net.Http.Client/HttpConnectionResponseContent.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/HttpConnectionResponseContent.cs
@@ -5,17 +5,17 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Net.Http.Client
 {
-    internal class HttpConnectionResponseContent : HttpContent
+    public class HttpConnectionResponseContent : HttpContent
     {
         private readonly HttpConnection _connection;
         private Stream _responseStream;
 
-        public HttpConnectionResponseContent(HttpConnection connection)
+        internal HttpConnectionResponseContent(HttpConnection connection)
         {
             _connection = connection;
         }
 
-        public void ResolveResponseStream(bool chunked)
+        internal void ResolveResponseStream(bool chunked)
         {
             if (_responseStream != null)
             {
@@ -34,6 +34,16 @@ namespace Microsoft.Net.Http.Client
                 // Raw, read until end and close
                 _responseStream = _connection.Transport;
             }
+        }
+
+        public WriteClosableStream HijackStream()
+        {
+            if (_responseStream != _connection.Transport)
+            {
+                throw new InvalidOperationException("cannot hijack chunked or content length stream");
+            }
+
+            return _connection.Transport;
         }
 
         protected override Task SerializeToStreamAsync(Stream stream, System.Net.TransportContext context)

--- a/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/ManagedHandler.cs
@@ -18,22 +18,29 @@ namespace Microsoft.Net.Http.Client
         public delegate Task<Stream> StreamOpener(string host, int port, CancellationToken cancellationToken);
         public delegate Task<Socket> SocketOpener(string host, int port, CancellationToken cancellationToken);
 
-        public ManagedHandler(StreamOpener opener)
+        public ManagedHandler()
         {
-            _streamOpener = opener;
-            if (_streamOpener == null)
-            {
-                _socketOpener = TCPSocketOpener;
-            }
+            _socketOpener = TCPSocketOpener;
         }
 
-        public ManagedHandler(SocketOpener opener = null)
+        public ManagedHandler(StreamOpener opener)
         {
-            _socketOpener = opener;
-            if (_socketOpener == null)
+            if (opener == null)
             {
-                _socketOpener = TCPSocketOpener;
+                throw new ArgumentNullException(nameof(opener));
             }
+
+            _streamOpener = opener;
+        }
+
+        public ManagedHandler(SocketOpener opener)
+        {
+            if (opener == null)
+            {
+                throw new ArgumentNullException(nameof(opener));
+            }
+
+            _socketOpener = opener;
         }
 
         public IWebProxy Proxy

--- a/Docker.DotNet/Microsoft.Net.Http.Client/WriteClosableStream.cs
+++ b/Docker.DotNet/Microsoft.Net.Http.Client/WriteClosableStream.cs
@@ -1,0 +1,11 @@
+using System.IO;
+
+namespace Microsoft.Net.Http.Client
+{
+    public abstract class WriteClosableStream : Stream
+    {
+        public abstract bool CanCloseWrite { get; }
+
+        public abstract void CloseWrite();
+    }
+}

--- a/Docker.DotNet/MultiplexedStream.cs
+++ b/Docker.DotNet/MultiplexedStream.cs
@@ -1,0 +1,161 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Net.Http.Client;
+
+namespace Docker.DotNet
+{
+    public class MultiplexedStream : IDisposable
+    {
+        private WriteClosableStream _stream;
+        private TargetStream _target;
+        private int _remaining;
+        private byte[] _header = new byte[8];
+        private bool _multiplexed;
+
+        const int bufferSize = 81920;
+
+        public MultiplexedStream(WriteClosableStream stream, bool multiplexed)
+        {
+            _stream = stream;
+            _multiplexed = multiplexed;
+        }
+
+        public enum TargetStream
+        {
+            StandardIn = 0,
+            StandardOut = 1,
+            StandardError = 2
+        }
+
+        public struct ReadResult
+        {
+            public int Count { get; set; }
+            public TargetStream Target { get; set; }
+            public bool EOF => Count == 0;
+        }
+
+        public void CloseWrite()
+        {
+            _stream.CloseWrite();
+        }
+
+        public Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _stream.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public async Task<ReadResult> ReadOutputAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            if (!_multiplexed)
+            {
+                return new ReadResult
+                {
+                    Count = await _stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false),
+                    Target = TargetStream.StandardOut
+                };
+            }
+
+            while (_remaining == 0)
+            {
+                for (var i = 0; i < _header.Length;)
+                {
+                    var n = await _stream.ReadAsync(_header, i, _header.Length - i, cancellationToken).ConfigureAwait(false);
+                    if (n == 0)
+                    {
+                        if (i == 0)
+                        {
+                            // End of the stream.
+                            return new ReadResult();
+                        }
+
+                        throw new EndOfStreamException();
+                    }
+
+                    i += n;
+                }
+
+                switch ((TargetStream)_header[0])
+                {
+                    case TargetStream.StandardIn:
+                    case TargetStream.StandardOut:
+                    case TargetStream.StandardError:
+                        _target = (TargetStream)_header[0];
+                        break;
+
+                    default:
+                        throw new IOException("unknown stream type");
+                }
+
+                _remaining = ((int)_header[4] << 24) |
+                            ((int)_header[5] << 16) |
+                            ((int)_header[6] << 8) |
+                            (int)_header[7];
+            }
+
+            var toRead = Math.Min(count, _remaining);
+            int read = await _stream.ReadAsync(buffer, offset, toRead, cancellationToken).ConfigureAwait(false);
+            if (read == 0)
+            {
+                throw new EndOfStreamException();
+            }
+
+            _remaining -= read;
+            return new ReadResult
+            {
+                Count = read,
+                Target = _target
+            };
+        }
+
+        public async Task CopyFromAsync(Stream input, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[bufferSize];
+            for (;;)
+            {
+                var count = await input.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                if (count == 0)
+                {
+                    break;
+                }
+
+                await WriteAsync(buffer, 0, count, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public async Task CopyOutputToAsync(Stream stdin, Stream stdout, Stream stderr, CancellationToken cancellationToken)
+        {
+            var buffer = new byte[bufferSize];
+            for (;;)
+            {
+                var result = await ReadOutputAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
+                if (result.EOF)
+                {
+                    return;
+                }
+
+                Stream stream = null;
+                switch (result.Target)
+                {
+                    case TargetStream.StandardIn:
+                        stream = stdin;
+                        break;
+                    case TargetStream.StandardOut:
+                        stream = stdin;
+                        break;
+                    case TargetStream.StandardError:
+                        stream = stdin;
+                        break;
+                }
+
+                await stream.WriteAsync(buffer, 0, result.Count, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)_stream).Dispose();
+        }
+    }
+}

--- a/Docker.DotNet/MultiplexedStream.cs
+++ b/Docker.DotNet/MultiplexedStream.cs
@@ -142,10 +142,10 @@ namespace Docker.DotNet
                         stream = stdin;
                         break;
                     case TargetStream.StandardOut:
-                        stream = stdin;
+                        stream = stdout;
                         break;
                     case TargetStream.StandardError:
-                        stream = stdin;
+                        stream = stderr;
                         break;
                 }
 

--- a/Docker.DotNet/QueryStringParameterAttribute.cs
+++ b/Docker.DotNet/QueryStringParameterAttribute.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq;
+#if NETSTANDARD1_3
 using System.Reflection;
+#endif
 
 namespace Docker.DotNet
 {

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -16,6 +16,7 @@
         "System.IO.Pipes": "4.0.0-beta-23516",
         "System.Linq": "4.0.1-rc3-23829",
         "System.Net.Http": "4.0.1-rc3-23829",
+        "System.Net.NameResolution": "4.0.0-beta-23516",
         "System.Net.Requests": "4.0.11-beta-23516",
         "System.Net.Security": "4.0.0-beta-23516",
         "System.Net.Sockets": "4.1.0-rc3-23829",

--- a/Docker.DotNet/project.json
+++ b/Docker.DotNet/project.json
@@ -24,7 +24,8 @@
         "System.Reflection.Extensions": "4.0.1-rc3-23829",
         "System.Reflection.TypeExtensions": "4.1.0-rc3-23829",
         "System.Runtime": "4.0.21-rc3-23829",
-        "System.Runtime.Serialization.Primitives": "4.1.0-rc3-23829"
+        "System.Runtime.Serialization.Primitives": "4.1.0-rc3-23829",
+        "System.Threading.Overlapped": "4.0.0"
       }
     },
     "net46": {


### PR DESCRIPTION
The key tricky part here is that we have to have a way to shut down the write path to notify Docker that stdin has closed. This is done with Socket.Shutdown() for sockets (TCP), and a zero-byte write for named pipe.